### PR TITLE
fix MAT autosave re-render

### DIFF
--- a/scripts/ctg.js
+++ b/scripts/ctg.js
@@ -44,7 +44,11 @@ export default class Ctg {
             this.manageModes();
 
             // Re-render Combat Tracker when mobs update not from autosave (FIXME: a re-render is needed, but is not being included to avoid a MAT bug. See https://github.com/Stendarpaval/mob-attack-tool/issues/40)
-            if (game.modules.get("mob-attack-tool")?.active && !game.settings.get("mob-attack-tool", "autoSaveCTGgroups")) Hooks.on("matMobUpdate", () => ui.combat?.render(true));
+            if (game.modules.get("mob-attack-tool")?.active) {
+                Hooks.on("matMobUpdate", () => {
+                    if (!game.settings.get("mob-attack-tool", "autoSaveCTGgroups")) ui.combat?.render(true);
+                });
+            };
 
             // Manage rolling group initiative if GM
             if (game.user?.isGM) {


### PR DESCRIPTION
- By moving the check for MAT's autosave setting into the hooked function, the combat tracker is only re-rendered outside of the autosaving process. This prevents the endless looping that can freeze the user's browser.
- Edit: To clarify, the problem was that previously the re-render function only gets added as a hook if MAT's autosaving setting is disabled *while Foundry is loading*. That means that it would work properly if the user would reload after enabling MAT's autosave setting. If they didn't, then the re-render function would still be hooked and start the endless loop. 
- I tested this on both Foundry v0.8.9 and V9, using MAT v0.3.14. It seems to solve the problem discussed [here](https://github.com/Stendarpaval/mob-attack-tool/issues/40). 