### PR TITLE
Fix mode buttons visibility for Foundry v10 (#35)

### DIFF
--- a/scripts/ctg.js
+++ b/scripts/ctg.js
@@ -333,7 +333,10 @@ export default class Ctg {
 		/** Create container for mode selection boxes */
 		const container = document.createElement("ul");
 		container.id = "ctg-modeContainer";
-		html.querySelector("#combat > #combat-round")?.after(container);
+		const combatRoundContainer =
+				 html.querySelector('.combat-sidebar .combat-tracker-header') // v10
+			|| html.querySelector('#combat > #combat-round') // v9
+		combatRoundContainer?.after(container);
 
 		// For each mode that exists
 		Ctg.MODES.forEach(mode => {


### PR DESCRIPTION
# PR

This PR is supposed to fix #35 by using the new element matchers, falling back to the old matchers for older versions of Foundry.

## Changes

* Fix mode buttons parent selection for Foundry v10
  * Defaults to the new matchers (`.combat-sidebar .combat-tracker-header`)
  * Falls back to the old matchers (`#combat > #combat-round`)

## Notes

* Tested with Foundry v10.288 and Foundry v9.280